### PR TITLE
Fix: Timer.timeFuture is executing the future twice

### DIFF
--- a/src/main/scala/com/gilt/gfc/time/Timer.scala
+++ b/src/main/scala/com/gilt/gfc/time/Timer.scala
@@ -49,8 +49,9 @@ trait Timer {
    */
   def timeFuture[T](report: Long => Unit)(future: => Future[T])(implicit ec: ExecutionContext): Future[T] = {
     val start = nanoClock()
-    future.onComplete(_ => report(nanoClock()- start))
-    future
+    val fut = future
+    fut.onComplete(_ => report(nanoClock()- start))
+    fut
   }
 
   /**

--- a/src/test/scala/com/gilt/gfc/time/TimerTest.scala
+++ b/src/test/scala/com/gilt/gfc/time/TimerTest.scala
@@ -5,6 +5,7 @@ import org.scalatest.{FunSuite, Matchers}
 
 import scala.concurrent.duration._
 import scala.concurrent.{Promise, Await, Future}
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Tests the Timer trait & object.
@@ -70,6 +71,20 @@ class TimerTest extends FunSuite with Matchers {
     var msg = ""
     timePrettyFormat("This took %s", msg = _)("lalalalalalalala") should equal("lalalalalalalala")
     msg should equal("This took 1 ns")
+  }
+
+  test("TimeFuture") {
+    // just test the side effect is executed only once
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val sideEffectsCount = new AtomicInteger()
+    def task() = Future.successful {
+      sideEffectsCount.incrementAndGet()
+      "lalalalalalala"
+    }
+
+    Await.result(Timer.timeFuture(_ => Unit)(task), Duration.Inf) should be("lalalalalalala")
+    sideEffectsCount.intValue() should equal(1)
   }
 
   test("TimeFuturePretty") {


### PR DESCRIPTION
Fix #2 
Given the current code, ```future: => Future[T]``` is evaluated every time we ask for it. The test run fine, but the side effect is executed twice.